### PR TITLE
Calendarプログラム作成

### DIFF
--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+require 'date'
+
+# インスタンス変数の初期設定
+@month = nil
+@year = nil
+
+# コマンドラインオプションの定義
+opt = OptionParser.new
+opt.on('-m MONTH', Integer) { |m| @month = m }
+opt.on('-y YEAR', Integer) { |y| @year = y }
+# 実行時にARGVから値を取り出す
+opt.parse(ARGV) 
+
+# 年月の初期化（未指定なら今日の年月）
+today = Date.today
+year = @year || today.year
+month = @month || today.month
+
+# 範囲チェック（1970〜2100年）
+if year < 1970 || year > 2100
+  puts "対応している年は1970年から2100年までです"
+  exit
+end
+
+# 月のチェック（1〜12）
+if month < 1 || month > 12
+  puts "月は1〜12の範囲で指定してください"
+  exit
+end
+
+# 開始日と終了日
+start_date = Date.new(year, month, 1)
+end_date = Date.new(year, month, -1)
+
+# ヘッダーの表示
+header = "#{year}年#{month}月"
+puts header.center(20)
+puts "日 月 火 水 木 金 土"
+
+# 1日の曜日（0=日, 6=土）に応じてスペースを出力
+#wdayはインスタンスメソッド
+# 0=日, 1=月, 2=火, 3=水, 4=木, 5=金, 6=土
+start_date.wday.times do
+  print "   "
+end
+
+# 日付を1日ずつ表示（右揃え2桁 + 半角スペース）
+date = start_date
+while date <= end_date
+  print date.day.to_s.rjust(2) + " "
+  print "\n" if date.wday == 6
+  date += 1
+end
+# 最後に改行
+puts "" 
+

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -3,29 +3,23 @@
 require 'optparse'
 require 'date'
 
-# インスタンス変数の初期設定
 @month = nil
 @year = nil
 
-# コマンドラインオプションの定義
 opt = OptionParser.new
 opt.on('-m MONTH', Integer) { |m| @month = m }
 opt.on('-y YEAR', Integer) { |y| @year = y }
-# 実行時にARGVから値を取り出す
 opt.parse(ARGV) 
 
-# 年月の初期化（未指定なら今日の年月）
 today = Date.today
 year = @year || today.year
 month = @month || today.month
 
-# 範囲チェック（1970〜2100年）
 if year < 1970 || year > 2100
   puts "対応している年は1970年から2100年までです"
   exit
 end
 
-# 月のチェック（1〜12）
 if month < 1 || month > 12
   puts "月は1〜12の範囲で指定してください"
   exit
@@ -35,14 +29,11 @@ end
 start_date = Date.new(year, month, 1)
 end_date = Date.new(year, month, -1)
 
-# ヘッダーの表示
 header = "#{year}年#{month}月"
 puts header.center(20)
 puts "日 月 火 水 木 金 土"
 
 # 1日の曜日（0=日, 6=土）に応じてスペースを出力
-#wdayはインスタンスメソッド
-# 0=日, 1=月, 2=火, 3=水, 4=木, 5=金, 6=土
 start_date.wday.times do
   print "   "
 end
@@ -54,6 +45,6 @@ while date <= end_date
   print "\n" if date.wday == 6
   date += 1
 end
-# 最後に改行
+
 puts "" 
 

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -34,17 +34,14 @@ puts header.center(20)
 puts "日 月 火 水 木 金 土"
 
 # 1日の曜日（0=日, 6=土）に応じてスペースを出力
-start_date.wday.times do
-  print "   "
-end
+print "   " * start_date.wday
 
 # 日付を1日ずつ表示（右揃え2桁 + 半角スペース）
-date = start_date
-while date <= end_date
+(start_date..end_date).each do |date|
   print date.day.to_s.rjust(2) + " "
-  print "\n" if date.wday == 6
+  puts if date.saturday?
   date += 1
 end
 
-puts "" 
+puts 
 


### PR DESCRIPTION
# 課題
今月のカレンダーを作成する
<details>
<summary>やること・頭の中を整理</summary>
＜課題を簡単にする＞

- オプションで処理できるようにする
- 最初の日と最後の日を指定
- 順番に表示させる
- 土曜日を表示した後に改行

＜optのチュートリアル＞
1. OptionParser オブジェクト opt を生成する
2. オプションを取り扱うブロックを opt に登録する
3. opt.parse(ARGV) でコマンドラインを実際に parse する

＜頭の中を整理＞
表示の仕方
①月　年
ーオプションを使って入力データを取得する
②週
曜日を表示させる
③日（土で改行）
- オプションで取得した始まりの日と終わりの日を取得する
- １日から終わりの日までを表示する
- 曜日まで空白で表示する
- それぞれを順番にしていく

＜条件を確認＞
少なくとも1970年から2100年までは正しく表示される
↑を追加する
</details>

<details>
<summary>調べたこと</summary>

## `year = @year || today.year`
**`@year` が設定されていればそれを使い、なければ today.year を使う**という意味
### 🔁 || の意味（論理和 / OR）
Rubyでは` a || b `は**a が 偽（nil または false）なら b を使う**という意味
## `opt.on('-m MONTH', Integer) { |m| @month = m }`
 OptionParser を使って、コマンドラインオプション -m を定義しているものです。
**`-m`オプションで整数（=月）を受け取り、それを `@month`に代入する**という意味
### 🔍 分解して解説
| 部分        | 意味              | 
| --------- | --------------- |
| `-m`      | コマンドラインオプションの名前 | 
| `'MONTH'` | ヘルプ表示のときの引数名    |
| `Integer` | 入力値の型が整数        |

### 🧾 補足：OptionParserの基本構文
```ruby
opt.on('オプション名 値のラベル', 型) { |値| 処理 }
```
## `Date.new(year, month, 1)`
Ruby の `Date`クラスを使って「指定した年と月の1日」を表す日付オブジェクトを作る処理
### ✅ 意味の分解
```ruby
Date.new(year, month, 1)
```
| 引数      | 意味        |
| ------- | --------- |
| `year`  | 年（例：2025） |
| `month` | 月（1〜12）   |
| `1`     | 日（＝1日）    |

### ✅ 実際の例
```ruby
require 'date'

d = Date.new(2025, 5, 1)
puts d              # => 2025-05-01
puts d.class        # => Date
puts d.wday         # => 4（木曜日）
```
### ✅ このコードで使われる理由
その月のカレンダー表示の開始点（1日）を決めること
そこから日付を `+1`ずつしていけば、月末までのすべての日付を順番に表示できる
### ✅ 補足：月末を求める方法も近い
```ruby
end_date = Date.new(year, month, -1)
```
`-1`とすることで、その月の最終日が自動で計算される（31日とか28日とか）
| コード                                     | 意味           |
| --------------------------------------- | ------------ |
| `Date.new(2025, 5, 1)`                  | 2025年5月1日を作る |
| `start_date = Date.new(year, month, 1)` | 指定年月の1日を取得する |
| `end_date = Date.new(year, month, -1)`  | 指定年月の末日を取得する |

## `opt.parse(ARGV) `とは
**コマンドライン引数（ARGV）を解析して、指定されたオプションに応じて値を処理するためのコード**
### 🔧 詳しく解説
```ruby
opt = OptionParser.new do |opts|
  opts.on('-m MONTH', Integer) { |m| @month = m }
  opts.on('-y YEAR', Integer) { |y| @year = y }
end
```
**`OptionParser`クラスのインスタンスで、「どんなオプションを受け取るか」を定義したもの**
### ARGV とは？
Rubyプログラムに渡された コマンドライン引数が格納されている配列
例）実行コマンドが` ruby calendar.rb -m 5 -y 2025` の場合
→ `ARGV = ["-m", "5", "-y", "2025"]`
### `opt.parse(ARGV) `とは？
「ARGV の中の引数を解析して、`-m` や `-y`の値を取り出して処理する」という意味
### `puts "#{year}年#{month}月"`中央揃えする方法
`日 月 火 水 木 金 土`
＝全角文字：7個（「日」「月」「火」「水」「木」「金」「土」）＋半角スペース：6個
> [!NOTE]
> ターミナルでは全角文字 = 半角2文字幅に見える
>文字数と表示幅は違う

## `@month = nil`
- インスタンス変数 `@month`を初期化している
- コードが読みやすく、かつ安全に動くようにするため

### ✅ なぜ nil を代入するのか？
「まだ値が決まっていない」ことを明示的に示すための 初期値の設定
```ruby
@month = nil   # 最初は値が未定
opt.on('-m MONTH', Integer) { |m| @month = m }  # コマンドラインから指定されたら上書き
```
## Rubyの`date`クラス範囲
### ✅ 前提：Ruby の Date クラスが使える範囲
- Date::ITALY（ユリウス暦 → グレゴリオ暦切り替え）に対応
- 西暦 -4712年 1月1日〜9999年12月31日 まで対応可能

## `rjust`は何？
**文字列メソッド**で、文字列の長さを指定した幅で**右寄せ**にして、足りない分を空白や指定した文字で埋めるため
### ✅ 基本構文
```ruby
文字列.rjust(幅, 埋める文字)
```
- 幅: 最終的な文字列の幅（何文字にしたいか）
- 埋める文字: 省略すると空白で埋める（省略可能）

### 🎯 なぜ rjust を使うのか？
**→ カレンダーの見た目を揃えるため**
| 日付 | `to_s` | `rjust(2)` |
| -- | ------ | ---------- |
| 3  | `"3"`  | `" 3"`     |
| 12 | `"12"` | `"12"`     |

### ✅ 補足：ゼロ埋めにしたい場合
```ruby
"3".rjust(2, '0')  # => "03"
```
</details>

ターミナルでの実行結果
```sh
./cal.rb -m 4 -y 2025
      2025年4月
日 月 火 水 木 金 土
       1  2  3  4  5
 6  7  8  9 10 11 12
13 14 15 16 17 18 19
20 21 22 23 24 25 26
27 28 29 30
```