### PR TITLE
Bowlingのプログラム

### DIFF
--- a/03.bowling/bowling.rb
+++ b/03.bowling/bowling.rb
@@ -1,0 +1,2 @@
+#!/usr/bin/env ruby
+

--- a/03.bowling/bowling.rb
+++ b/03.bowling/bowling.rb
@@ -1,2 +1,59 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
+def parse_input(input)
+  input.split(',').map { |s| s == 'X' ? 10 : s.to_i }
+end
+
+def make_frames(shots)
+  frames = []
+  i = 0
+
+  9.times do
+    if shots[i] == 10
+      frames << [10]
+      i += 1
+    else
+      frames << [shots[i], shots[i + 1]]
+      i += 2
+    end
+  end
+
+  frames << shots[i..]
+end
+
+def calculate_score(frames)
+  total = 0
+
+  frames.each_with_index do |frame, idx|
+    total += if idx < 9
+               if frame[0] == 10
+                 10 + strike_bonus(frames, idx)
+               elsif frame.sum == 10
+                 10 + spare_bonus(frames, idx)
+               else
+                 frame.sum
+               end
+             else
+               frame.sum
+             end
+  end
+
+  total
+end
+
+def strike_bonus(frames, idx)
+  next_frame = frames[idx + 1]
+
+  if next_frame[0] == 10 && frames[idx + 2]
+    10 + frames[idx + 2][0]
+  else
+    next_frame[0] + (next_frame[1] || 0)
+  end
+end
+
+def spare_bonus(frames, idx)
+  frames[idx + 1][0]
+end
+
+parse_input(ARGV[0])


### PR DESCRIPTION
# Terminalで実行した結果
```bash
./bowling.rb 0,10,1,5,0,0,0,0,X,X,X,5,1,8,1,0,4
[[0, 10], [1, 5], [0, 0], [0, 0], [10], [10], [10], [5, 1], [8, 1], [0, 4]]
107
```
```bash
% ./bowling.rb 6,3,9,0,0,3,8,2,7,3,X,9,1,8,0,X,6,4,5
[[6, 3], [9, 0], [0, 3], [8, 2], [7, 3], [10], [9, 1], [8, 0], [10], [6, 4, 5]]
139
```
```bash
% ./bowling.rb 6,3,9,0,0,3,8,2,7,3,X,9,1,8,0,X,X,X,X
[[6, 3], [9, 0], [0, 3], [8, 2], [7, 3], [10], [9, 1], [8, 0], [10], [10, 10, 10]]
164
```
```bash
% ./bowling.rb 0,10,1,5,0,0,0,0,X,X,X,5,1,8,1,0,4
[[0, 10], [1, 5], [0, 0], [0, 0], [10], [10], [10], [5, 1], [8, 1], [0, 4]]
107
```
```bash
% ./bowling.rb 6,3,9,0,0,3,8,2,7,3,X,9,1,8,0,X,X,0,0
[[6, 3], [9, 0], [0, 3], [8, 2], [7, 3], [10], [9, 1], [8, 0], [10], [10, 0, 0]]
134
```
```bash
% ./bowling.rb 6,3,9,0,0,3,8,2,7,3,X,9,1,8,0,X,X,1,8
[[6, 3], [9, 0], [0, 3], [8, 2], [7, 3], [10], [9, 1], [8, 0], [10], [10, 1, 8]]
144
```
```bash
 % ./bowling.rb X,X,X,X,X,X,X,X,X,X,X,X
[[10], [10], [10], [10], [10], [10], [10], [10], [10], [10, 10, 10]]
300
```
```bash
% ./bowling.rb X,X,X,X,X,X,X,X,X,X,X,2
[[10], [10], [10], [10], [10], [10], [10], [10], [10], [10, 10, 2]]
292
```
# rubocopでエラー確認
```bash
rubocop
Your Gemfile lists the gem rubocop-fjord (>= 0) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once.
While it's not a problem now, it could cause errors if you change the version of one of them later.
rubocop-performance extension supports plugin, specify `plugins: rubocop-performance` instead of `require: rubocop-performance` in /Users/kanako.itoyama/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-fjord-0.3.0/config/rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

Inspecting 1 file
W

Offenses:

bowling.rb:1:1: C: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
#!/usr/bin/env ruby
^
bowling.rb:4:1: C: [Correctable] Layout/IndentationStyle: Tab detected in indentation.
	input.split(',').map { |s| s == 'X' ? 10 : s.to_i }
^
bowling.rb:4:1: C: [Correctable] Layout/IndentationWidth: Use 2 (not 1) spaces for indentation.
	input.split(',').map { |s| s == 'X' ? 10 : s.to_i }
^
bowling.rb:8:1: C: [Correctable] Layout/IndentationStyle: Tab detected in indentation.
	frames = []
^
bowling.rb:8:1: C: [Correctable] Layout/IndentationWidth: Use 2 (not 1) spaces for indentation.
	frames = []
^
bowling.rb:9:3: C: [Correctable] Layout/IndentationConsistency: Inconsistent indentation detected.
  i = 0
  ^^^^^
bowling.rb:11:3: C: [Correctable] Layout/IndentationConsistency: Inconsistent indentation detected.
  9.times do ...
  ^^^^^^^^^^
bowling.rb:21:3: C: [Correctable] Layout/IndentationConsistency: Inconsistent indentation detected.
  frames << shots[i..]
  ^^^^^^^^^^^^^^^^^^^^
bowling.rb:29:7: C: [Correctable] Style/ConditionalAssignment: Use the return of the conditional for variable assignment and comparison.
      if frame[0] == 10  ...
      ^^^^^^^^^^^^^^^^^^
bowling.rb:29:24: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
      if frame[0] == 10
                       ^
bowling.rb:31:28: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
      elsif frame.sum == 10
                           ^
bowling.rb:47:44: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
  if next_frame[0] == 10 && frames[idx + 2]
                                           ^
bowling.rb:58:1: W: [Correctable] Lint/UselessAssignment: Useless assignment to variable - shots.
shots = parse_input(ARGV[0])
^^^^^
bowling.rb:59:1: C: [Correctable] Layout/TrailingEmptyLines: 1 trailing blank lines detected.

1 file inspected, 14 offenses detected, 14 offenses autocorrectable
```
# 出力の見方
| 項目                             | 内容                               |
| ------------------------------ | -------------------------------- |
| `bowling.rb:4:1`               | **ファイル名と場所**（4行目・1文字目）           |
| `C`                            | **重大度**（C: Convention = 見た目の問題）  |
| `[Correctable]`                | **自動で直せる**エラー（`rubocop -A`で修正可能） |
| `Layout/IndentationStyle`      | **ルールの名前**（ここでは「インデントの仕方」）       |
| `Tab detected in indentation.` | **エラー内容**（スペースじゃなくてタブを使ってる）      |
| `^`                            | エラーの箇所を示す記号（ここで問題だよ、という印）        |

# よく出るエラー
| エラー                                     | 意味                                           | 解決方法                |
| --------------------------------------- | -------------------------------------------- | ------------------- |
| `Missing frozen string literal comment` | ファイルの先頭に `# frozen_string_literal: true` がない | 1行目に追加する            |
| `Tab detected in indentation`           | インデントに**タブ**を使ってる                            | スペース2つに変える（Tabキー禁止） |
| `TrailingWhitespace`                    | 行末に余計なスペースがある                                | スペースを消す             |
| `UselessAssignment`                     | 変数に代入してるけど、使ってない                             | 不要なら削除するか使う         |
| `TrailingEmptyLines`                    | ファイルの最後に空行がある                                | 最後の空行を消す            |
##  `#frozen_string_literal: true`の意味
通常のruby（変更できる）
```ruby
str = "こんにちは"
str << "世界"   # 変更できる
puts str       #=> "こんにちは世界"
```
`#frozen_string_literal: true`をつける
```ruby
# frozen_string_literal: true
str = "こんにちは"
str << "世界"   # 💥 エラー！変更しようとすると怒られる
```
✅ これを使うメリット
| 効果       | 内容                            |
| -------- | ----------------------------- |
| ✅ 高速になる  | 文字列のコピーや再生成が減るので、処理が速くなる場合がある |
| ✅ 安全になる  | うっかり文字列を変更してバグになるのを防げる        |
| ✅ メモリの節約 | 同じ文字列をいちいち作らなくて済む（共有される）      |
# `rubocop -A`で自動修正
```bash
 rubocop -A
Your Gemfile lists the gem rubocop-fjord (>= 0) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once.
While it's not a problem now, it could cause errors if you change the version of one of them later.
rubocop-performance extension supports plugin, specify `plugins: rubocop-performance` instead of `require: rubocop-performance` in /Users/kanako.itoyama/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-fjord-0.3.0/config/rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

Inspecting 1 file
W

Offenses:

bowling.rb:5:1: C: [Corrected] Layout/IndentationStyle: Tab detected in indentation.
	input.split(',').map { |s| s == 'X' ? 10 : s.to_i }
^
bowling.rb:5:1: C: [Corrected] Layout/IndentationWidth: Use 2 (not 1) spaces for indentation.
	input.split(',').map { |s| s == 'X' ? 10 : s.to_i }
^
bowling.rb:5:1: C: [Corrected] Layout/IndentationWidth: Use 2 (not 3) spaces for indentation.
   input.split(',').map { |s| s == 'X' ? 10 : s.to_i }
^^^
bowling.rb:9:1: C: [Corrected] Layout/IndentationStyle: Tab detected in indentation.
	frames = []
^
bowling.rb:9:1: C: [Corrected] Layout/IndentationWidth: Use 2 (not 1) spaces for indentation.
	frames = []
^
bowling.rb:9:1: C: [Corrected] Layout/IndentationWidth: Use 2 (not 3) spaces for indentation.
   frames = []
^^^
bowling.rb:10:2: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected.
 i = 0
 ^^^^^
bowling.rb:10:3: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected.
  i = 0
  ^^^^^
bowling.rb:10:4: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected.
   i = 0
   ^^^^^
bowling.rb:12:2: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected.
 9.times do ...
 ^^^^^^^^^^
bowling.rb:12:3: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected.
  9.times do ...
  ^^^^^^^^^^
bowling.rb:12:4: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected.
   9.times do ...
   ^^^^^^^^^^
bowling.rb:22:2: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected.
 frames << shots[i..]
 ^^^^^^^^^^^^^^^^^^^^
bowling.rb:22:3: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected.
  frames << shots[i..]
  ^^^^^^^^^^^^^^^^^^^^
bowling.rb:22:4: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected.
   frames << shots[i..]
   ^^^^^^^^^^^^^^^^^^^^
bowling.rb:29:5: C: [Corrected] Style/ConditionalAssignment: Use the return of the conditional for variable assignment and comparison.
    if idx < 9 ...
    ^^^^^^^^^^
bowling.rb:30:7: C: [Corrected] Layout/IndentationWidth: Use 2 (not -7) spaces for indentation.
      if frame[0] == 10
      ^^^^^^^
bowling.rb:30:7: C: [Corrected] Style/ConditionalAssignment: Use the return of the conditional for variable assignment and comparison.
      if frame[0] == 10  ...
      ^^^^^^^^^^^^^^^^^^
bowling.rb:30:24: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
      if frame[0] == 10
                       ^
bowling.rb:31:9: C: [Corrected] Layout/IndentationWidth: Use 2 (not -7) spaces for indentation.
        10 + strike_bonus(frames, idx)
        ^^^^^^^
bowling.rb:31:16: C: [Corrected] Layout/IndentationWidth: Use 2 (not 11) spaces for indentation.
                          10 + strike_bonus(frames, idx)
               ^^^^^^^^^^^
bowling.rb:32:7: C: [Corrected] Layout/ElseAlignment: Align elsif with if.
      elsif frame.sum == 10
      ^^^^^
bowling.rb:32:16: C: [Corrected] Layout/ElseAlignment: Align elsif with if.
               elsif frame.sum == 10
               ^^^^^
bowling.rb:32:28: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
      elsif frame.sum == 10
                           ^
bowling.rb:33:9: C: [Corrected] Layout/IndentationWidth: Use 2 (not -7) spaces for indentation.
        10 + spare_bonus(frames, idx)
        ^^^^^^^
bowling.rb:33:16: C: [Corrected] Layout/IndentationWidth: Use 2 (not 11) spaces for indentation.
                          10 + spare_bonus(frames, idx)
               ^^^^^^^^^^^
bowling.rb:34:7: C: [Corrected] Layout/ElseAlignment: Align else with if.
      else
      ^^^^
bowling.rb:34:16: C: [Corrected] Layout/ElseAlignment: Align else with if.
               else
               ^^^^
bowling.rb:35:9: C: [Corrected] Layout/IndentationWidth: Use 2 (not -7) spaces for indentation.
        frame.sum
        ^^^^^^^
bowling.rb:35:16: C: [Corrected] Layout/IndentationWidth: Use 2 (not 11) spaces for indentation.
                          frame.sum
               ^^^^^^^^^^^
bowling.rb:36:16: W: [Corrected] Layout/EndAlignment: end at 36, 15 is not aligned with if at 30, 6.
               end
               ^^^
bowling.rb:37:5: C: [Corrected] Layout/ElseAlignment: Align else with if.
    else
    ^^^^
bowling.rb:38:7: C: [Corrected] Layout/IndentationWidth: Use 2 (not -7) spaces for indentation.
      frame.sum
      ^^^^^^^
bowling.rb:48:44: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.
  if next_frame[0] == 10 && frames[idx + 2]
                                           ^
bowling.rb:59:1: W: [Corrected] Lint/UselessAssignment: Useless assignment to variable - shots.
shots = parse_input(ARGV[0])
^^^^^
bowling.rb:60:1: C: [Corrected] Layout/TrailingEmptyLines: 1 trailing blank lines detected.

1 file inspected, 36 offenses detected, 36 offenses corrected
```
# 修正後
```ruby
 % rubocop
Your Gemfile lists the gem rubocop-fjord (>= 0) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once.
While it's not a problem now, it could cause errors if you change the version of one of them later.
rubocop-performance extension supports plugin, specify `plugins: rubocop-performance` instead of `require: rubocop-performance` in /Users/kanako.itoyama/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rubocop-fjord-0.3.0/config/rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

Inspecting 1 file
.

1 file inspected, no offenses detected
```
### Rubocopの自動修正（rubocop -A）を少なくする＝「最初から自動修正されない、きれいなコードを書く」ためのコツと方法
#### Rubocopが自動修正する対象
| ルール名                          | 内容               |
| ----------------------------- | ---------------- |
| `Layout/IndentationStyle`     | インデントがタブ→スペースへ修正 |
| `Layout/TrailingWhitespace`   | 行末の余計なスペース削除     |
| `Style/StringLiterals`        | `'` と `"` の統一    |
| `Layout/EmptyLineBetweenDefs` | メソッド間の空行の追加      |

#### 自動修正が出ないようにする方法（= 最初から守る）
 ① タブではなくスペース2個を使う
② メソッドの間には空行を1つ入れる
③ 行末に空白を入れない
④ # frozen_string_literal: true を1行目に書く
#### Rubocopのルールを事前に知るには？
- `rubocop --auto-gen-config`でルールを一覧出力
- `.rubocop.yml`にどのルールが有効か書いて確認
ルールの詳細を見る：https://docs.rubocop.org/rubocop/