### PR TITLE
Retry_fizzbuzz

### DIFF
--- a/01.fizzbuzz/fizzbuzz.rb
+++ b/01.fizzbuzz/fizzbuzz.rb
@@ -1,13 +1,13 @@
 
 (1..20).each do |i|
-    if i % 3 == 0 && i % 5 == 0
-        puts "FizzBuzz"
-    elsif i % 3 == 0
-        puts "Fizz"
-    elsif i % 5 == 0
-        puts "Buzz"
-    else
-        puts i
-    end
+  if (i % 3 == 0) && (i % 5 == 0)
+    puts "FizzBuzz"
+  elsif i % 3 == 0
+    puts "Fizz"
+  elsif i % 5 == 0
+    puts "Buzz"
+  else
+    puts i
+  end
 end
 

--- a/01.fizzbuzz/fizzbuzz.rb
+++ b/01.fizzbuzz/fizzbuzz.rb
@@ -1,13 +1,14 @@
-
-(1..20).each do |i|
-  if (i % 3 == 0) && (i % 5 == 0)
-    puts "FizzBuzz"
-  elsif i % 3 == 0
-    puts "Fizz"
-  elsif i % 5 == 0
-    puts "Buzz"
-  else
-    puts i
-  end
+i = 1
+20.times do
+    if i % 3 == 0 && i % 5 == 0
+        puts "FizzBuzz"
+    elsif i % 3 == 0
+        puts "Fizz"
+    elsif i % 5 == 0
+        puts "Buzz"
+    else
+        puts i
+    end
+    i += 1
 end
 

--- a/01.fizzbuzz/fizzbuzz.rb
+++ b/01.fizzbuzz/fizzbuzz.rb
@@ -1,0 +1,13 @@
+
+(1..20).each do |i|
+  if (i % 3 == 0) && (i % 5 == 0)
+    puts "FizzBuzz"
+  elsif i % 3 == 0
+    puts "Fizz"
+  elsif i % 5 == 0
+    puts "Buzz"
+  else
+    puts i
+  end
+end
+

--- a/01.fizzbuzz/fizzbuzz.rb
+++ b/01.fizzbuzz/fizzbuzz.rb
@@ -1,5 +1,5 @@
-i = 1
-20.times do
+
+(1..20).each do |i|
     if i % 3 == 0 && i % 5 == 0
         puts "FizzBuzz"
     elsif i % 3 == 0
@@ -9,6 +9,5 @@ i = 1
     else
         puts i
     end
-    i += 1
 end
 


### PR DESCRIPTION
https://github.com/kanapiii22/ruby-practices/pull/2 から新しくブランチを作成しましたが、https://github.com/fjordllc/ruby-practices/pull/550 fjordllc内にできたので本来あるべき場所(kanapiii2)に作成しました。
プルリクの名前で伝わるようにしないといけないと思いました。
プルリクの名前≠コミット内容は今回の反省点です。
プルリクとブランチの名前をretry_fizzbuzzに変更しました。

🧭 方針（やること）
1. `retry-fizzbuzz`ブランチで中身を全部削除
2. `fizzbuzz`に関する 4 つのコミットだけを`cherry-pick`
3. 必要なファイル（fizzbuzz.rb など）だけ残す
4. 不要なファイルを削除して`commit`
5. `push`する